### PR TITLE
Implement matmul

### DIFF
--- a/src/grad.rs
+++ b/src/grad.rs
@@ -1,7 +1,10 @@
 pub mod matmul;
 pub mod mul;
 
-use std::cell::{Ref, RefCell, RefMut};
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    rc::Rc,
+};
 
 use ndarray::{Array, ArrayView, Dimension, IntoNdProducer, Zip};
 
@@ -9,7 +12,7 @@ pub type Tensor<D> = Array<f32, D>;
 
 /// Trait to represent a computational graph of a function to be diffrentiated.
 /// All node in the graph implements this trait.
-pub trait Function {
+pub trait Function: Clone {
     type Dim: Dimension;
 
     /// Return the reference to this node's value which has computed in forward path for given inputs.
@@ -33,8 +36,8 @@ pub trait Function {
 /// To diffrentiate, call `requires_grad()`.
 #[derive(Clone)]
 pub struct Variable<D> {
-    data: RefCell<Tensor<D>>,
-    gradient: RefCell<Tensor<D>>,
+    data: Rc<RefCell<Tensor<D>>>,
+    gradient: Rc<RefCell<Tensor<D>>>,
     requires_grad: bool,
 }
 
@@ -46,8 +49,8 @@ where
         let shape = data.raw_dim();
 
         Self {
-            data: RefCell::new(data),
-            gradient: RefCell::new(Tensor::zeros(shape)),
+            data: Rc::new(RefCell::new(data)),
+            gradient: Rc::new(RefCell::new(Tensor::zeros(shape))),
             requires_grad: false,
         }
     }

--- a/src/grad.rs
+++ b/src/grad.rs
@@ -1,3 +1,4 @@
+pub mod matmul;
 pub mod mul;
 
 use std::cell::{Ref, RefCell, RefMut};

--- a/src/grad.rs
+++ b/src/grad.rs
@@ -18,6 +18,13 @@ pub trait Function: Clone {
     /// Return the reference to this node's value which has computed in forward path for given inputs.
     fn data(&self) -> Ref<Tensor<Self::Dim>>;
 
+    /// Initialize gradient with the tensor whose elements are all 1.0.
+    /// This is called when the struct instance is the root of the computation graph.
+    fn init_grad(&self) {
+        let shape = self.gradient().raw_dim();
+        *self.gradient_mut() = Tensor::ones(shape);
+    }
+
     /// Return the reference to the gradient of the whole function with respect to this node.
     fn gradient(&self) -> Ref<Tensor<Self::Dim>>;
 

--- a/src/grad/matmul.rs
+++ b/src/grad/matmul.rs
@@ -1,0 +1,103 @@
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    rc::Rc,
+};
+
+use ndarray::{linalg::general_mat_mul, Dimension, Ix2};
+
+use crate::grad::{send_gradient, Function, Tensor};
+
+pub fn matmul<Lhs, Rhs>(lhs: &Rc<Lhs>, rhs: &Rc<Rhs>) -> Rc<MatrixMultiplication<Lhs, Rhs>>
+where
+    Lhs: Function<Dim = Ix2>,
+    Rhs: Function<Dim = Ix2>,
+{
+    Rc::new(MatrixMultiplication::new(lhs, rhs))
+}
+
+pub struct MatrixMultiplication<Lhs, Rhs>
+where
+    Lhs: Function,
+    Rhs: Function,
+{
+    data: RefCell<Tensor<Ix2>>,
+    lhs: Rc<Lhs>,
+    rhs: Rc<Rhs>,
+    gradient: RefCell<Tensor<Ix2>>,
+}
+
+impl<Lhs, Rhs> MatrixMultiplication<Lhs, Rhs>
+where
+    Lhs: Function<Dim = Ix2>,
+    Rhs: Function<Dim = Ix2>,
+{
+    pub fn new(lhs: &Rc<Lhs>, rhs: &Rc<Rhs>) -> Self {
+        Self {
+            data: RefCell::new(Tensor::zeros((lhs.data().nrows(), rhs.data().ncols()))),
+            lhs: Rc::clone(lhs),
+            rhs: Rc::clone(rhs),
+            gradient: RefCell::new(Tensor::zeros(lhs.data().raw_dim())),
+        }
+    }
+
+    pub fn init_grad(&self) {
+        *self.gradient.borrow_mut() = Tensor::ones(self.lhs.data().raw_dim());
+    }
+}
+
+impl<Lhs, Rhs> Function for MatrixMultiplication<Lhs, Rhs>
+where
+    Lhs: Function<Dim = Ix2>,
+    Rhs: Function<Dim = Ix2>,
+{
+    type Dim = Ix2;
+
+    fn data(&self) -> Ref<Tensor<Self::Dim>> {
+        self.data.borrow()
+    }
+
+    fn gradient(&self) -> Ref<Tensor<Self::Dim>> {
+        self.gradient.borrow()
+    }
+
+    fn gradient_mut(&self) -> RefMut<Tensor<Self::Dim>> {
+        self.gradient.borrow_mut()
+    }
+
+    fn forward(&self) {
+        self.lhs.forward();
+        self.rhs.forward();
+        general_mat_mul(
+            1.0,
+            &*self.lhs.data(),
+            &*self.rhs.data(),
+            1.0,
+            &mut *self.data.borrow_mut(),
+        );
+    }
+
+    fn backward(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{assert_rel_eq_arr2, grad::Variable};
+
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use ndarray::arr2;
+
+    #[test]
+    fn forward_mat_mul() {
+        let w = arr2(&[[1.0, 2.0], [-1.0, 3.0], [1.0, -1.0]]);
+        let x = arr2(&[[-1.0, 3.0, 2.0], [4.0, 1.0, 0.5]]);
+        let expected = x.dot(&w);
+
+        let w = Rc::new(Variable::new(w));
+        let x = Rc::new(Variable::new(x).requires_grad());
+        let z = matmul(&x, &w);
+        z.forward();
+        assert_rel_eq_arr2!(z.data().clone(), expected);
+    }
+}

--- a/src/grad/matmul.rs
+++ b/src/grad/matmul.rs
@@ -41,11 +41,6 @@ where
             gradient: Rc::new(RefCell::new(Tensor::zeros(shape))),
         }
     }
-
-    pub fn init_grad(&self) {
-        let shape = self.gradient().raw_dim();
-        *self.gradient.borrow_mut() = Tensor::ones(shape);
-    }
 }
 
 impl<Lhs, Rhs> Function for MatrixMultiplication<Lhs, Rhs>

--- a/src/grad/mul.rs
+++ b/src/grad/mul.rs
@@ -23,7 +23,7 @@ where
     Lhs: Function,
     Rhs: Function,
 {
-    // TODO: this cannot restrict the dimentionality of rhs.
+    // TODO: this cannot restrict the shape of rhs.
     data: Rc<RefCell<Tensor<D>>>,
     lhs: Lhs,
     rhs: Rhs,
@@ -47,12 +47,6 @@ where
             gradient: Rc::new(RefCell::new(Tensor::zeros(lhs.data().raw_dim()))),
             buffer_for_backward: RefCell::new(Tensor::zeros(lhs.data().raw_dim())),
         }
-    }
-
-    /// Initialize gradient with the tensor whose elements are all 1.0.
-    /// This is called when the struct instance is the root of the computation graph.
-    pub fn init_grad(&self) {
-        *self.gradient.borrow_mut() = Tensor::ones(self.lhs.data().raw_dim());
     }
 }
 

--- a/src/grad/mul.rs
+++ b/src/grad/mul.rs
@@ -48,6 +48,8 @@ where
         }
     }
 
+    /// Initialize gradient with the tensor whose elements are all 1.0.
+    /// This is called when the struct instance is the root of the computation graph.
     pub fn init_grad(&self) {
         *self.gradient.borrow_mut() = Tensor::ones(self.lhs.data().raw_dim());
     }


### PR DESCRIPTION
close #7
- Forward path of matmul
- Implement backward for matmul
- Move `Rc` inside a struct which implements `Function`
- Bring up `init_grad()` to `Function` trait
