### PR TITLE
`Model` trait

### DIFF
--- a/src/grad.rs
+++ b/src/grad.rs
@@ -18,6 +18,12 @@ pub type DynTensor = ArrayD<f32>;
 pub(crate) type Broadcasted<LhsDim, RhsDim> = <LhsDim as DimMax<RhsDim>>::Output;
 pub(crate) type BroadTensor<Lhs, Rhs> = Tensor<Broadcasted<Lhs, Rhs>>;
 
+pub use addition::{add, Addition};
+pub use matmul::{matmul, MatrixMultiplication};
+pub use mse::{mse, MeanSquaredError};
+pub use relu::{relu, Relu};
+pub use sigmoid::{sigmoid, Sigmoid};
+
 /// Trait to represent a computational graph of a function to be diffrentiated.
 /// All node in the graph implements this trait.
 pub trait Function: Clone {

--- a/src/grad.rs
+++ b/src/grad.rs
@@ -201,6 +201,7 @@ where
 /// Sum up along specified `axis` in-place.
 /// This reduces the dimentionality of `x` by 1.
 fn sum_axis_inplace(x: &mut DynTensor, axis: Axis) {
+    // TODO: Consider to use `accumulate_axis_inplace()` instead.
     let (accumulated, rest) = x.view_mut().split_at(axis, 1);
     Zip::from(accumulated.remove_axis(axis))
         .and(rest.lanes(axis))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod activation;
 pub mod grad;
 pub mod layer;
 pub mod loss;
+pub mod model;
 pub mod network;
 
 #[macro_export]

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,11 +3,7 @@ use std::marker::PhantomData;
 use ndarray::{Array, Ix1, Ix2};
 use ndarray_rand::{rand_distr::Uniform, RandomExt};
 
-use crate::grad::{
-    addition::{add, Addition},
-    matmul::{matmul, MatrixMultiplication},
-    Function, Variable,
-};
+use crate::grad::{add, matmul, Addition, Function, MatrixMultiplication, Variable};
 
 /// Trait to represent learning model.
 pub trait Model<In, Out>

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,9 +1,9 @@
 use std::marker::PhantomData;
 
-use ndarray::{Array, Ix1, Ix2};
+use ndarray::{Array, Ix1, Ix2, Dimension};
 use ndarray_rand::{rand_distr::Uniform, RandomExt};
 
-use crate::grad::{add, matmul, Addition, Function, MatrixMultiplication, Variable};
+use crate::grad::{self, add, matmul, Addition, Function, MatrixMultiplication, Variable, relu, sigmoid};
 
 /// Trait to represent learning model.
 pub trait Model<In, Out>
@@ -43,6 +43,32 @@ where
         input: In,
     ) -> Addition<MatrixMultiplication<In, Variable<Ix2>>, Variable<Ix1>> {
         add(&matmul(&input, &self.weight), &self.bias)
+    }
+}
+
+/// Layer applying ReLU.
+pub struct Relu;
+
+impl<D, In> Model<In, grad::Relu<D, In>> for Relu
+where
+    D: Dimension,
+    In: Function<Dim = D, GradDim = D>,
+{
+    fn forward(&self, input: In) -> grad::Relu<D, In> {
+        relu(&input)
+    }
+}
+
+/// Layer applying sigmoid.
+pub struct Sigmoid;
+
+impl<D, In> Model<In, grad::Sigmoid<D, In>> for Sigmoid
+where
+    D: Dimension,
+    In: Function<Dim = D, GradDim = D>,
+{
+    fn forward(&self, input: In) -> grad::Sigmoid<D, In> {
+        sigmoid(&input)
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,113 @@
+use std::marker::PhantomData;
+
+use ndarray::{Array, Ix1, Ix2};
+use ndarray_rand::{rand_distr::Uniform, RandomExt};
+
+use crate::grad::{
+    addition::{add, Addition},
+    matmul::{matmul, MatrixMultiplication},
+    Function, Variable,
+};
+
+/// Trait to represent learning model.
+pub trait Model<In, Out>
+where
+    In: Function,
+    Out: Function,
+{
+    fn forward(&self, input: In) -> Out;
+}
+
+/// Linear transformation layer.
+pub struct Linear {
+    weight: Variable<Ix2>,
+    bias: Variable<Ix1>,
+}
+
+impl Linear {
+    pub fn new(in_features: usize, out_features: usize) -> Self {
+        let weight = Variable::new(Array::random(
+            (in_features, out_features),
+            Uniform::new(-1.0, 1.0),
+        ))
+        .requires_grad();
+        let bias =
+            Variable::new(Array::random((out_features,), Uniform::new(-1.0, 1.0))).requires_grad();
+
+        Self { weight, bias }
+    }
+}
+
+impl<In> Model<In, Addition<MatrixMultiplication<In, Variable<Ix2>>, Variable<Ix1>>> for Linear
+where
+    In: Function<Dim = Ix2, GradDim = Ix2>,
+{
+    fn forward(
+        &self,
+        input: In,
+    ) -> Addition<MatrixMultiplication<In, Variable<Ix2>>, Variable<Ix1>> {
+        add(&matmul(&input, &self.weight), &self.bias)
+    }
+}
+
+pub struct Compose<F, S, In, Mid, Out>
+where
+    F: Model<In, Mid>,
+    S: Model<Mid, Out>,
+    In: Function,
+    Mid: Function,
+    Out: Function,
+{
+    first: F,
+    second: S,
+    _in: PhantomData<In>,
+    _mid: PhantomData<Mid>,
+    _out: PhantomData<Out>,
+}
+
+/// Compose two models.
+/// Incoming data is applied to `first`, then applied to `second`.
+pub fn compose<F, S, In, Mid, Out>(first: F, second: S) -> Compose<F, S, In, Mid, Out>
+where
+    F: Model<In, Mid>,
+    S: Model<Mid, Out>,
+    In: Function,
+    Mid: Function,
+    Out: Function,
+{
+    Compose {
+        first,
+        second,
+        _in: PhantomData,
+        _mid: PhantomData,
+        _out: PhantomData,
+    }
+}
+
+impl<F, S, In, Mid, Out> Model<In, Out> for Compose<F, S, In, Mid, Out>
+where
+    F: Model<In, Mid>,
+    S: Model<Mid, Out>,
+    In: Function,
+    Mid: Function,
+    Out: Function,
+{
+    fn forward(&self, input: In) -> Out {
+        let mid = self.first.forward(input);
+        self.second.forward(mid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ndarray::arr2;
+
+    #[test]
+    fn forward_compose() {
+        let model = compose(Linear::new(2, 4), Linear::new(4, 1));
+        let x = Variable::new(arr2(&[[1.0, 0.5], [2.0, 3.0]]));
+        model.forward(x);
+    }
+}

--- a/tests/noisy_func.rs
+++ b/tests/noisy_func.rs
@@ -1,4 +1,4 @@
-use ami::grad::{addition::add, matmul::matmul, mse::mse, relu::relu, Function, Tensor, Variable};
+use ami::grad::{add, matmul, mse, relu, Function, Tensor, Variable};
 use ndarray::{s, Array, Array2, ArrayView2, Axis, Dimension, Zip};
 use ndarray_rand::{
     rand::{thread_rng, Rng},


### PR DESCRIPTION
close #19
- Define `Model`, `Linear` and `Compose`
- Re-export components in `crate::grad`
- Define `Relu` and `Sigmoid` impls `Model`
- `Model` owns previous layer
- Replace `NetIn` with `Variable<D>`
- Add comment
