### PR TITLE
Implement basic metrics for classification

### DIFF
--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -1,11 +1,12 @@
 use ami::{
     data::DataLoader,
     grad::{softmax_cross_entropy, Function, Variable},
-    metrics::confusion_matrix,
+    metrics::{accuracy, confusion_matrix},
     model::{Chainable, Input, Linear, Model, Relu},
     optimizer::GradientDescent,
-    sequential, OneHotEncoder,
+    sequential,
     utils::train_test_split,
+    OneHotEncoder,
 };
 use csv::Reader;
 use ndarray::Array2;
@@ -45,7 +46,6 @@ fn main() {
     let y_train = encoder.encode(&y_train);
     let x_test =
         Array2::from_shape_vec((x_test.len(), 4), x_test.into_iter().flatten().collect()).unwrap();
-    let y_test = encoder.encode(&y_test);
 
     let mut loader = DataLoader::new(x_train, y_train).shuffle();
 
@@ -84,10 +84,9 @@ fn main() {
 
     let y_pred = model.forward(Variable::new(x_test));
     y_pred.forward();
-    let confusion_matrix = confusion_matrix(
-        &encoder.decode(y_test),
-        &encoder.decode(y_pred.data().clone()),
-        &labels,
-    );
+    let y_pred = encoder.decode(y_pred.data().clone());
+    let confusion_matrix = confusion_matrix(&y_test, &y_pred, &labels);
+
+    println!("accuracy: {}", accuracy(&y_test, &y_pred));
     println!("{:?}", confusion_matrix);
 }

--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -1,41 +1,91 @@
-use ami::network::Network;
+use ami::{
+    data::DataLoader,
+    grad::{softmax_cross_entropy, Function, Variable},
+    metrics::confusion_matrix,
+    model::{Chainable, Input, Linear, Model, Relu, Sigmoid},
+    optimizer::GradientDescent,
+    sequential, OneHotEncoder,
+    utils::train_test_split,
+};
 use csv::Reader;
 use ndarray::Array2;
 use std::path::Path;
 
-fn convert_iris_kinds_to_one_hot(kind: &str) -> Vec<f64> {
-    match kind {
-        "Iris-setosa" => vec![1.0, 0.0, 0.0],
-        "Iris-versicolor" => vec![0.0, 1.0, 0.0],
-        "Iris-virginica" => vec![0.0, 0.0, 1.0],
-        _ => panic!("Unknown iris kind: {}", kind),
-    }
-}
-
 // Load iris dataset available here: https://www.kaggle.com/arshid/iris-flower-dataset
-fn load_iris(file_path: impl AsRef<Path>) -> (Array2<f64>, Array2<f64>) {
+fn load_iris(file_path: impl AsRef<Path>) -> (Vec<Vec<f32>>, Vec<String>) {
     let mut reader = Reader::from_path(file_path).unwrap();
     let mut xs = Vec::new();
     let mut ys = Vec::new();
-    let mut n_records = 0;
     for row in reader.records() {
         let row = row.unwrap();
-        n_records += 1;
-        for i in 0..4 {
-            xs.push(row[i].parse::<f64>().unwrap());
-        }
-        let y = convert_iris_kinds_to_one_hot(&row[4]);
-        ys.extend(y.iter());
+        let y = row[4].to_string();
+        let features = row
+            .into_iter()
+            .take(4)
+            .map(|r| r.parse().unwrap())
+            .collect();
+        xs.push(features);
+        ys.push(y);
     }
-    dbg!(ys.len(), n_records);
-    let xs = Array2::from_shape_vec((n_records, 4), xs).unwrap();
-    let ys = Array2::from_shape_vec((n_records, 3), ys).unwrap();
     (xs, ys)
 }
 
 fn main() {
-    let mut _network = Network::new(0.5);
     let (xs, ys) = load_iris("./IRIS.csv");
-    dbg!(xs);
-    dbg!(ys);
+    let labels = vec!["Iris-setosa", "Iris-versicolor", "Iris-virginica"]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<_>>();
+    let encoder = OneHotEncoder::new(&labels);
+
+    let (x_train, y_train, x_test, y_test) = train_test_split(xs, ys, 0.25);
+    let x_train =
+        Array2::from_shape_vec((x_train.len(), 4), x_train.into_iter().flatten().collect())
+            .unwrap();
+    let y_train = encoder.encode(&y_train);
+    let x_test =
+        Array2::from_shape_vec((x_test.len(), 4), x_test.into_iter().flatten().collect()).unwrap();
+    let y_test = encoder.encode(&y_test);
+
+    let mut loader = DataLoader::new(x_train, y_train).shuffle();
+
+    let model = sequential!(
+        Input,
+        Linear::new(4, 6),
+        Relu::new(),
+        Linear::new(6, 3),
+        Sigmoid::new()
+    );
+    let optimizer = GradientDescent::new(1e-3);
+
+    let epochs = 3000;
+    let batch_size = 16;
+    for epoch in 0..epochs {
+        let mut total_loss = 0.0;
+        for (input, target) in loader.batch(batch_size) {
+            let input = Variable::new(input);
+            let target = Variable::new(target);
+
+            let network = model.forward(input);
+            let loss = softmax_cross_entropy(&network, &target);
+            loss.forward();
+            loss.backward();
+            model.update_parameters(&optimizer);
+            model.zero_gradient();
+
+            total_loss += loss.data()[()];
+        }
+        if epoch % 10 == 0 {
+            println!("epoch {}: total loss = {}", epoch, total_loss);
+        }
+    }
+
+    let y_pred = model.forward(Variable::new(x_test));
+    y_pred.forward();
+    let confusion_matrix = confusion_matrix(
+        &encoder.decode(y_test),
+        &encoder.decode(y_pred.data().clone()),
+        &labels,
+    );
+    println!("{:?}", confusion_matrix);
 }

--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -1,7 +1,7 @@
 use ami::{
     data::DataLoader,
     grad::{softmax_cross_entropy, Function, Variable},
-    metrics::{accuracy, confusion_matrix},
+    metrics::{accuracy, confusion_matrix, precision_recall_fscore},
     model::{Chainable, Input, Linear, Model, Relu},
     optimizer::GradientDescent,
     sequential,
@@ -87,6 +87,10 @@ fn main() {
     let y_pred = encoder.decode(y_pred.data().clone());
     let confusion_matrix = confusion_matrix(&y_test, &y_pred, &labels);
 
-    println!("accuracy: {}", accuracy(&y_test, &y_pred));
+    let (precision, recall, f1) = precision_recall_fscore(&y_test, &y_pred, &labels);
+    println!("precision: {}", precision);
+    println!("recall:    {}", recall);
+    println!("f1_score   {}", f1);
+    println!("accuracy:  {}", accuracy(&y_test, &y_pred));
     println!("{:?}", confusion_matrix);
 }

--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -2,7 +2,7 @@ use ami::{
     data::DataLoader,
     grad::{softmax_cross_entropy, Function, Variable},
     metrics::confusion_matrix,
-    model::{Chainable, Input, Linear, Model, Relu, Sigmoid},
+    model::{Chainable, Input, Linear, Model, Relu},
     optimizer::GradientDescent,
     sequential, OneHotEncoder,
     utils::train_test_split,
@@ -51,12 +51,13 @@ fn main() {
 
     let model = sequential!(
         Input,
-        Linear::new(4, 6),
+        Linear::new(4, 10),
         Relu::new(),
-        Linear::new(6, 3),
-        Sigmoid::new()
+        Linear::new(10, 10),
+        Relu::new(),
+        Linear::new(10, 3)
     );
-    let optimizer = GradientDescent::new(1e-3);
+    let optimizer = GradientDescent::new(1e-2);
 
     let epochs = 3000;
     let batch_size = 16;
@@ -75,6 +76,7 @@ fn main() {
 
             total_loss += loss.data()[()];
         }
+
         if epoch % 10 == 0 {
             println!("epoch {}: total loss = {}", epoch, total_loss);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod data;
 pub mod grad;
 pub mod layer;
 pub mod loss;
+pub mod metrics;
 pub mod model;
 pub mod network;
 pub mod optimizer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod metrics;
 pub mod model;
 pub mod network;
 pub mod optimizer;
+pub mod utils;
 
 #[macro_export]
 macro_rules! assert_rel_eq_arr1 {
@@ -50,7 +51,7 @@ where
     Label: Hash + Eq + Clone,
 {
     /// Record labels to convert.
-    pub fn new(label_kinds: Vec<Label>) -> Self {
+    pub fn new(label_kinds: &[Label]) -> Self {
         let label_to_id = label_kinds
             .iter()
             .cloned()
@@ -59,7 +60,7 @@ where
             .collect();
         Self {
             label_to_id,
-            id_to_label: label_kinds,
+            id_to_label: label_kinds.to_vec(),
         }
     }
 
@@ -119,8 +120,11 @@ mod tests {
 
     #[test]
     fn encode_labels() {
-        let label_kinds = vec!["A", "B", "C"].into_iter().map(String::from).collect();
-        let encoder = OneHotEncoder::new(label_kinds);
+        let label_kinds = vec!["A", "B", "C"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>();
+        let encoder = OneHotEncoder::new(&label_kinds);
 
         let labels = vec!["A", "A", "C", "B", "C"]
             .into_iter()
@@ -141,8 +145,11 @@ mod tests {
 
     #[test]
     fn decode_one_hot() {
-        let label_kinds = vec!["A", "B", "C"].into_iter().map(String::from).collect();
-        let encoder = OneHotEncoder::new(label_kinds);
+        let label_kinds = vec!["A", "B", "C"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>();
+        let encoder = OneHotEncoder::new(&label_kinds);
 
         let one_hot_vecs = arr2(&[
             [1.0, 0.0, 0.0],

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,39 @@
+/// Construct confusion matrix from `y_true` and `y_pred`.
+/// For correct result, the items in `label_kinds` must be unique.
+pub fn confusion_matrix<Label>(
+    y_true: &[Label],
+    y_pred: &[Label],
+    label_kinds: &[Label],
+) -> Vec<Vec<usize>>
+where
+    Label: Eq + Clone,
+{
+    label_kinds
+        .iter()
+        .map(|true_label| {
+            label_kinds.iter().map(|pred_label| {
+                y_true
+                    .iter()
+                    .zip(y_pred.iter())
+                    .filter(|(t, p)| t.clone() == true_label && p.clone() == pred_label)
+                    .count()
+            })
+            .collect()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_confusion_matrix() {
+        let y_true = vec![0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2];
+        let y_pred = vec![0, 0, 0, 1, 0, 1, 1, 2, 0, 1, 1, 2];
+        assert_eq!(
+            vec![vec![3, 1, 0], vec![1, 2, 1], vec![1, 2, 1]],
+            confusion_matrix(&y_true, &y_pred, &[0, 1, 2])
+        );
+    }
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,3 +1,16 @@
+/// Compute accuracy of the predicted labels `y_pred` to the correct labels `y_true`.
+pub fn accuracy<Label>(y_true: &[Label], y_pred: &[Label]) -> f32
+where
+    Label: Eq,
+{
+    let n_corrects = y_true
+        .iter()
+        .zip(y_pred.iter())
+        .filter(|(t, p)| t == p)
+        .count();
+    n_corrects as f32 / y_true.len() as f32
+}
+
 /// Construct confusion matrix from `y_true` and `y_pred`.
 /// An item in i-th row and j-th column is the number of predicted j-th label where a true label is
 /// i-th one.
@@ -29,7 +42,16 @@ where
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
+
+    #[test]
+    fn test_accuracy() {
+        let y_true = vec![0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2];
+        let y_pred = vec![0, 0, 0, 1, 0, 1, 1, 2, 0, 1, 1, 2];
+        assert_relative_eq!(0.5, accuracy(&y_true, &y_pred))
+    }
 
     #[test]
     fn test_confusion_matrix() {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,6 @@
 /// Construct confusion matrix from `y_true` and `y_pred`.
+/// An item in i-th row and j-th column is the number of predicted j-th label where a true label is
+/// i-th one.
 /// For correct result, the items in `label_kinds` must be unique.
 pub fn confusion_matrix<Label>(
     y_true: &[Label],
@@ -11,14 +13,16 @@ where
     label_kinds
         .iter()
         .map(|true_label| {
-            label_kinds.iter().map(|pred_label| {
-                y_true
-                    .iter()
-                    .zip(y_pred.iter())
-                    .filter(|(t, p)| t.clone() == true_label && p.clone() == pred_label)
-                    .count()
-            })
-            .collect()
+            label_kinds
+                .iter()
+                .map(|pred_label| {
+                    y_true
+                        .iter()
+                        .zip(y_pred.iter())
+                        .filter(|(t, p)| &(*t).clone() == true_label && &(*p).clone() == pred_label)
+                        .count()
+                })
+                .collect()
         })
         .collect()
 }
@@ -34,6 +38,20 @@ mod tests {
         assert_eq!(
             vec![vec![3, 1, 0], vec![1, 2, 1], vec![1, 2, 1]],
             confusion_matrix(&y_true, &y_pred, &[0, 1, 2])
+        );
+    }
+
+    #[test]
+    fn test_confusion_matrix_on_string_label() {
+        let y_true = vec![
+            "ant", "ant", "ant", "cat", "cat", "cat", "dog", "dog", "dog",
+        ];
+        let y_pred = vec![
+            "ant", "ant", "cat", "cat", "cat", "cat", "ant", "cat", "dog",
+        ];
+        assert_eq!(
+            vec![vec![2, 1, 0], vec![0, 3, 0], vec![1, 1, 1]],
+            confusion_matrix(&y_true, &y_pred, &["ant", "cat", "dog"])
         );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,11 @@ use ndarray_rand::rand::{prelude::SliceRandom, thread_rng};
 
 /// Split dataset into train and test data.
 /// `test_ratio` is a ratio of the number of test data to the whole dataset.
-pub fn train_test_split<X, Y>(x: Vec<X>, y: Vec<Y>, test_ratio: f32) -> (Vec<X>, Vec<Y>, Vec<X>, Vec<Y>)
+pub fn train_test_split<X, Y>(
+    x: Vec<X>,
+    y: Vec<Y>,
+    test_ratio: f32,
+) -> (Vec<X>, Vec<Y>, Vec<X>, Vec<Y>)
 where
     X: Clone,
     Y: Clone,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,23 @@
+use ndarray_rand::rand::{prelude::SliceRandom, thread_rng};
+
+/// Split dataset into train and test data.
+/// `test_ratio` is a ratio of the number of test data to the whole dataset.
+pub fn train_test_split<X, Y>(x: Vec<X>, y: Vec<Y>, test_ratio: f32) -> (Vec<X>, Vec<Y>, Vec<X>, Vec<Y>)
+where
+    X: Clone,
+    Y: Clone,
+{
+    assert_eq!(x.len(), y.len());
+
+    let mut rng = thread_rng();
+    let n_trains = (x.len() as f32 * (1.0 - test_ratio)) as usize;
+
+    let mut zipped = x.into_iter().zip(y.into_iter()).collect::<Vec<_>>();
+    zipped.shuffle(&mut rng);
+    let (mut x_train, mut y_train): (Vec<_>, Vec<_>) = zipped.into_iter().unzip();
+
+    let x_test = x_train.split_off(n_trains);
+    let y_test = y_train.split_off(n_trains);
+
+    (x_train, y_train, x_test, y_test)
+}


### PR DESCRIPTION
close #27
- Implement confusion matrix
- Implement iris classification
- Improve iris classification by adding layer and changing lr
- Implement accuracy
- Calculate precision and recall with macro avg.
- Implement f1 score
- Handle corner cases that precision or recall become NaN
